### PR TITLE
chore: fix tests for clippy

### DIFF
--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -243,7 +243,7 @@ mod tests {
 )
                 "#;
             let wasm = wat::parse_str(code).unwrap();
-            let store = Store::from_bytes(&wasm, None).unwrap();
+            let store = Store::from_bytes(wasm, None).unwrap();
             Rc::new(RefCell::new(store))
         };
 


### PR DESCRIPTION
Fixes this linter error:

```
error: the borrowed expression implements the required traits
   --> tests/spec.rs:246:43
    |
246 |             let store = Store::from_bytes(&wasm, None).unwrap();
    |                                           ^^^^^ help: change this to: `wasm`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args
    = note: `-D clippy::needless-borrows-for-generic-args` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::needless_borrows_for_generic_args)]`

error: could not compile `chibiwasm` (test "spec") due to previous error
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.
```